### PR TITLE
HP-1838: add see-no-mans to owner-staff

### DIFF
--- a/src/files/items.php
+++ b/src/files/items.php
@@ -1063,6 +1063,7 @@ return [
             'owner-staff',
             'move.read-all',
             'move.get-directions',
+            'see-no-mans',
         ],
     ],
     'role:almighty' => [

--- a/src/files/source/tree.php
+++ b/src/files/source/tree.php
@@ -464,6 +464,7 @@ return [
         'move.read-all',
         'part.read-all-hierarchy',
         'move.get-directions',
+        'see-no-mans',
     ],
     'role:almighty' => [
         'role:admin',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced access control by adding new permissions for the 'staff' and 'almighty' roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->