### PR TITLE
HP-1930: restict set-nss

### DIFF
--- a/src/files/items.php
+++ b/src/files/items.php
@@ -993,6 +993,7 @@ return [
             'domain.push',
             'domain.force-push',
             'domain.force-send-foa',
+            'domain.force-set-nss',
             'domain.approve-trasfer-out',
             'domain.maintain',
         ],
@@ -2661,6 +2662,14 @@ return [
     'deny:domain.force-send-foa' => [
         'type' => 2,
         'description' => 'Prohibits force-send-foa operation on the domain',
+    ],
+    'domain.force-set-nss' => [
+        'type' => 2,
+        'description' => 'Allows force-set-nss operation on the domain',
+    ],
+    'deny:domain.force-set-nss' => [
+        'type' => 2,
+        'description' => 'Prohibits force-set-nss operation on the domain',
     ],
     'domain.approve-trasfer-out' => [
         'type' => 2,

--- a/src/files/source/metadata.php
+++ b/src/files/source/metadata.php
@@ -739,6 +739,9 @@ return [
     'deny:domain.set-nss' => [
         'description' => 'Prohibits set-nss operation on the domain',
     ],
+    'deny:domain.force-set-nss' => [
+        'description' => 'Prohibits force-set-nss operation on the domain',
+    ],
     'deny:domain.unfreeze' => [
         'description' => 'Prohibits unfreezeing of the domain',
     ],
@@ -1155,6 +1158,9 @@ return [
     ],
     'domain.set-nss' => [
         'description' => 'Allows set-nss operation on the domain',
+    ],
+    'domain.force-set-nss' => [
+        'description' => 'Allows force-set-nss operation on the domain',
     ],
     'domain.unfreeze' => [
         'description' => 'Allows unfreezeing of the domain',

--- a/src/files/source/tree.php
+++ b/src/files/source/tree.php
@@ -431,7 +431,7 @@ return [
         'role:domain.manager',
         'domain.freeze', 'domain.unfreeze',
         'domain.push', 'domain.force-push',
-        'domain.force-send-foa',
+        'domain.force-send-foa', 'domain.force-set-nss',
         'domain.approve-trasfer-out',
         'domain.maintain',
     ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for 'domain.force-set-nss' operations, allowing more granular control over domain management with new permissions settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->