### PR TITLE
HP-1964: added blacklist role

### DIFF
--- a/src/files/items.php
+++ b/src/files/items.php
@@ -186,6 +186,15 @@ return [
             'role:consumption.manager',
         ],
     ],
+    'role:blacklist.manager' => [
+        'type' => 1,
+        'children' => [
+            'blacklist.read',
+            'blacklist.create',
+            'blacklist.update',
+            'blacklist.delete',
+        ],
+    ],
     'role:config.manager' => [
         'type' => 1,
         'description' => 'The role is generally assigned to staff who are in charge of publicly offered servers configuration management',
@@ -820,6 +829,7 @@ return [
             'role:contact.user',
             'role:server.user',
             'role:hosting.user',
+            'role:blacklist.manager',
         ],
     ],
     'role:admin' => [
@@ -1079,6 +1089,7 @@ return [
             'move.read-all',
             'move.get-directions',
             'see-no-mans',
+            'role:blacklist.manager',
         ],
     ],
     'role:almighty' => [
@@ -1093,6 +1104,7 @@ return [
             'role:config.manager',
             'role:costprice.manager',
             'role:pnl.master',
+            'role:blacklist.manager',
             'domain.freeze',
             'domain.force-push',
             'domain.delete',
@@ -1516,6 +1528,30 @@ return [
     'deny:consumption.read-all' => [
         'type' => 2,
         'description' => 'Prohibits read-all operation on the consumption',
+    ],
+    'blacklist.read' => [
+        'type' => 2,
+    ],
+    'deny:blacklist.read' => [
+        'type' => 2,
+    ],
+    'blacklist.create' => [
+        'type' => 2,
+    ],
+    'deny:blacklist.create' => [
+        'type' => 2,
+    ],
+    'blacklist.update' => [
+        'type' => 2,
+    ],
+    'deny:blacklist.update' => [
+        'type' => 2,
+    ],
+    'blacklist.delete' => [
+        'type' => 2,
+    ],
+    'deny:blacklist.delete' => [
+        'type' => 2,
     ],
     'config.read' => [
         'type' => 2,

--- a/src/files/source/tree.php
+++ b/src/files/source/tree.php
@@ -67,6 +67,10 @@ return [
     'role:consumption.master' => [
         'consumption.read-all', 'role:consumption.user', 'role:consumption.manager',
     ],
+    // BLACKLIST
+    'role:blacklist.manager' => [
+        'blacklist.read', 'blacklist.create', 'blacklist.update', 'blacklist.delete',
+    ],
     // CONFIG
     'role:config.manager' => [
         'config.read', 'config.create', 'config.update', 'config.delete',
@@ -340,6 +344,7 @@ return [
         'role:contact.user',
         'role:server.user',
         'role:hosting.user',
+        'role:blacklist.manager',
     ],
     'role:admin' => [
         'admin',
@@ -471,6 +476,7 @@ return [
         'part.read-all-hierarchy',
         'move.get-directions',
         'see-no-mans',
+        'role:blacklist.manager',
     ],
     'role:almighty' => [
         'role:admin',
@@ -481,6 +487,7 @@ return [
         'role:config.manager',
         'role:costprice.manager',
         'role:pnl.master',
+        'role:blacklist.manager',
         'domain.freeze',
         'domain.force-push',
         'domain.delete',

--- a/tests/unit/CheckAccessTrait.php
+++ b/tests/unit/CheckAccessTrait.php
@@ -130,6 +130,7 @@ trait CheckAccessTrait
             'request.read', 'request.create', 'request.update', 'request.delete',
             'vhost.read', 'vhost.create', 'vhost.update', 'vhost.delete',
             'ip.read', 'service.read',
+            'blacklist.read', 'blacklist.create', 'blacklist.update', 'blacklist.delete',
         ]);
     }
 
@@ -167,6 +168,7 @@ trait CheckAccessTrait
             'vhost.read', 'vhost.create', 'vhost.update', 'vhost.delete',
             'ip.read', 'ip.create', 'ip.update', 'ip.delete',
             'service.read', 'service.create', 'service.update', 'service.delete',
+            'blacklist.read', 'blacklist.create', 'blacklist.update', 'blacklist.delete',
         ]);
     }
 
@@ -211,6 +213,7 @@ trait CheckAccessTrait
             'request.read', 'request.create', 'request.update', 'request.delete',
             'vhost.read', 'vhost.create', 'vhost.update', 'vhost.delete',
             'ip.read', 'service.read', 'client.notify',
+            'blacklist.read', 'blacklist.create', 'blacklist.update', 'blacklist.delete',
         ]);
     }
 
@@ -249,6 +252,7 @@ trait CheckAccessTrait
             'request.read', 'request.create', 'request.update', 'request.delete',
             'vhost.read', 'vhost.create', 'vhost.update', 'vhost.delete',
             'ip.read', 'service.read', 'client.notify',
+            'blacklist.read', 'blacklist.create', 'blacklist.update', 'blacklist.delete',
         ]);
     }
 
@@ -288,6 +292,7 @@ trait CheckAccessTrait
             'vhost.read', 'vhost.create', 'vhost.update', 'vhost.delete',
             'ip.read', 'service.read', 'client.notify',
             'integration.read', 'integration.create', 'integration.update', 'integration.delete',
+            'blacklist.read', 'blacklist.create', 'blacklist.update', 'blacklist.delete',
         ]);
     }
 
@@ -356,6 +361,7 @@ trait CheckAccessTrait
             'vhost.read', 'vhost.create', 'vhost.update', 'vhost.delete',
             'ip.read', 'ip.create', 'ip.update', 'ip.delete',
             'service.read', 'service.create', 'service.update', 'service.delete',
+            'blacklist.read', 'blacklist.create', 'blacklist.update', 'blacklist.delete',
         ]);
     }
 
@@ -422,6 +428,7 @@ trait CheckAccessTrait
             'service.read', 'service.create', 'service.update', 'service.delete',
             'costprice.read', 'costprice.create', 'costprice.update', 'costprice.delete',
             'pnl.read', 'pnl.read-expenses', 'pnl.update',
+            'blacklist.read', 'blacklist.create', 'blacklist.update', 'blacklist.delete',
         ]);
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new role `blacklist.manager` with permissions to read, create, update, and delete blacklist entries.

- **Permissions**
  - Enhanced permissions for various roles (`contact.user`, `server.user`, `hosting.user`, `almighty`) to include blacklist management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->