### PR TITLE
HP-2069: add access-subclients to role client

### DIFF
--- a/src/files/items.php
+++ b/src/files/items.php
@@ -843,6 +843,7 @@ return [
             'role:finance.user',
             'role:sale.user',
             'client.notify',
+            'access-subclients',
         ],
     ],
     'role:support' => [

--- a/src/files/source/tree.php
+++ b/src/files/source/tree.php
@@ -357,6 +357,7 @@ return [
         'role:finance.user',
         'role:sale.user',
         'client.notify',
+        'access-subclients',
     ],
     'role:support' => [
         'access-subclients', 'support',

--- a/tests/unit/CheckAccessTrait.php
+++ b/tests/unit/CheckAccessTrait.php
@@ -87,7 +87,7 @@ trait CheckAccessTrait
         $this->assertEqualsCanonicalizing($result, [
             'role:almighty', 'access-subclients',
             'role:support', 'role:admin', 'role:accounter', 'role:manager',
-            'role:reseller', 'role:owner', 'role:junior-manager', 'role:staff-admin',
+            'role:reseller', 'role:owner', 'role:junior-manager', 'role:staff-admin', 'role:client',
         ]);
     }
 
@@ -127,6 +127,7 @@ trait CheckAccessTrait
             'request.read', 'request.create', 'request.update', 'request.delete',
             'vhost.read', 'vhost.create', 'vhost.update', 'vhost.delete',
             'ip.read', 'service.read', 'client.notify',
+	    'access-subclients',
         ]);
     }
 
@@ -533,7 +534,7 @@ trait CheckAccessTrait
 
     public function testLimited()
     {
-        $this->auth->setAssignments('role:client,deny:pay,deny:deposit,deny:domain.push,deny:server.pay,deny:server.read,deny:server.control-power,deny:server.control-system,deny:server.set-note,deny:ip.read,deny:service.read,deny:domain.delete-agp,deny:domain.set-nss', 'user:limited');
+        $this->auth->setAssignments('role:client,deny:pay,deny:deposit,deny:domain.push,deny:server.pay,deny:server.read,deny:server.control-power,deny:server.control-system,deny:server.set-note,deny:ip.read,deny:service.read,deny:domain.delete-agp,deny:domain.set-nss,deny:access-subclients', 'user:limited');
 
         $this->assertAccesses('user:limited', [
             'have-goods',
@@ -553,6 +554,7 @@ trait CheckAccessTrait
             'mail.read', 'mail.create', 'mail.update', 'mail.delete',
             'request.read', 'request.create', 'request.update', 'request.delete',
             'vhost.read', 'vhost.create', 'vhost.update', 'vhost.delete', 'client.notify',
+
         ]);
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new permission, `access-subclients`, for the `role:client` and `role:support`, enabling enhanced management of subclients.
  
- **Bug Fixes**
	- Updated access tests to reflect new permissions for `role:client` and `role:support`, ensuring accurate access control. 

- **Tests**
	- Enhanced tests for user access permissions to include the newly added `access-subclients` permission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->