### PR TITLE
HP-2335 added 'see-no-mans' to 'role:staff-admin'

### DIFF
--- a/src/files/items.php
+++ b/src/files/items.php
@@ -890,6 +890,7 @@ return [
             'role:admin',
             'role:server.staff-admin',
             'role:hub.staff-admin',
+            'see-no-mans',
         ],
     ],
     'role:staff-manager' => [

--- a/src/files/source/tree.php
+++ b/src/files/source/tree.php
@@ -388,6 +388,7 @@ return [
         'role:admin',
         'role:server.staff-admin',
         'role:hub.staff-admin',
+        'see-no-mans',
     ],
     'role:staff-manager' => [
         'role:bill.staff-manager',

--- a/tests/unit/CheckAccessTrait.php
+++ b/tests/unit/CheckAccessTrait.php
@@ -242,6 +242,7 @@ trait CheckAccessTrait
             'client.read-ip',
             'ticket.read-templates', 'ticket.read-statistics', 'ticket.set-private', 'ticket.set-recipient', 'ticket.set-time',
             'part.read-administrative',
+            'see-no-mans',
         ]);
     }
 
@@ -455,8 +456,8 @@ trait CheckAccessTrait
             'purse.set-credit','server.read-wizzard','server.read-legend','server.read-system-info', 'server.read-financial-info',
             'server.read-billing','server.assign-hub','plan.set-note',
             'client.read-financial-info', 'client.read-requisite', 'client.read-referral', 'client.read-deleted', 'client.read-ip',
-            'part.read-administrative', 'ticket.read-templates', 'ticket.read-statistics', 'ticket.set-private', 'ticket.set-recipient', 'ticket.set-time'
-
+            'part.read-administrative', 'ticket.read-templates', 'ticket.read-statistics', 'ticket.set-private', 'ticket.set-recipient', 'ticket.set-time',
+            'see-no-mans',
         ]);
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Extended permissions for staff administrators and managers with a new access right to additional functionalities.
- **Tests**
	- Updated test coverage to ensure the new permission is correctly recognized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->