### PR TITLE
HQD-69: Add installment-plan permissions

### DIFF
--- a/src/files/items.php
+++ b/src/files/items.php
@@ -2611,6 +2611,7 @@ return [
     ],
     'deny:installment-plan.read' => [
         'type' => 2,
+        'description' => 'Prohibits reading of the installment plan',
     ],
     'installment-plan.delete' => [
         'type' => 2,
@@ -2618,6 +2619,7 @@ return [
     ],
     'deny:installment-plan.delete' => [
         'type' => 2,
+        'description' => 'Prohibits deleting of the installment plan',
     ],
     'part.read' => [
         'type' => 2,

--- a/src/files/items.php
+++ b/src/files/items.php
@@ -2619,7 +2619,7 @@ return [
     ],
     'deny:installment-plan.delete' => [
         'type' => 2,
-        'description' => 'Prohibits deleting of the installment plan',
+        'description' => 'Prohibits deleting and restoring of the installment plan',
     ],
     'part.read' => [
         'type' => 2,

--- a/src/files/items.php
+++ b/src/files/items.php
@@ -693,6 +693,22 @@ return [
             'target.delete',
         ],
     ],
+    'role:installment-plan.user' => [
+        'type' => 1,
+        'description' => 'The role is generally assigned to users who have access to installment plan information',
+        'children' => [
+            'installment-plan.read',
+            'sale.read',
+        ],
+    ],
+    'role:installment-plan.manager' => [
+        'type' => 1,
+        'description' => 'The role is generally assigned to staff who are in charge of installment plan management',
+        'children' => [
+            'role:installment-plan.user',
+            'installment-plan.delete',
+        ],
+    ],
     'role:part.user' => [
         'type' => 1,
         'description' => 'The role is generally assigned to users who have access to part information',
@@ -881,6 +897,7 @@ return [
             'role:hosting.user',
             'role:finance.user',
             'role:sale.user',
+            'role:installment-plan.user',
             'client.notify',
             'access-subclients',
         ],
@@ -1188,6 +1205,7 @@ return [
             'see-no-mans',
             'role:blacklist.manager',
             'role:audit.user',
+            'role:installment-plan.manager',
         ],
     ],
     'role:almighty' => [
@@ -2586,6 +2604,20 @@ return [
     'deny:target.delete' => [
         'type' => 2,
         'description' => 'Prohibits deleting of the target',
+    ],
+    'installment-plan.read' => [
+        'type' => 2,
+        'description' => 'Read installment plans',
+    ],
+    'deny:installment-plan.read' => [
+        'type' => 2,
+    ],
+    'installment-plan.delete' => [
+        'type' => 2,
+        'description' => 'Delete and restore installment plans',
+    ],
+    'deny:installment-plan.delete' => [
+        'type' => 2,
     ],
     'part.read' => [
         'type' => 2,

--- a/src/files/items.php
+++ b/src/files/items.php
@@ -2616,6 +2616,7 @@ return [
     'installment-plan.delete' => [
         'type' => 2,
         'description' => 'Delete and restore installment plans',
+        'internal' => true,
     ],
     'deny:installment-plan.delete' => [
         'type' => 2,

--- a/src/files/source/metadata.php
+++ b/src/files/source/metadata.php
@@ -205,6 +205,12 @@ return [
     'role:part.master' => [
         'description' => 'The role is generally assigned to staff who have exceptionally high permissions for the parts management',
     ],
+    'role:installment-plan.user' => [
+        'description' => 'The role is generally assigned to users who have access to installment plan information',
+    ],
+    'role:installment-plan.manager' => [
+        'description' => 'The role is generally assigned to staff who are in charge of installment plan management',
+    ],
     'role:model.user' => [
         'description' => 'The role is generally assigned to users who have access to models information',
     ],

--- a/src/files/source/metadata.php
+++ b/src/files/source/metadata.php
@@ -210,6 +210,7 @@ return [
     ],
     'role:installment-plan.manager' => [
         'description' => 'The role is generally assigned to staff who are in charge of installment plan management',
+        'internal' => true,
     ],
     'role:model.user' => [
         'description' => 'The role is generally assigned to users who have access to models information',
@@ -1513,6 +1514,7 @@ return [
     ],
     'installment-plan.delete' => [
         'description' => 'Delete and restore installment plans',
+        'internal' => true,
     ],
     'deny:installment-plan.read' => [
         'description' => 'Prohibits reading of the installment plan',

--- a/src/files/source/metadata.php
+++ b/src/files/source/metadata.php
@@ -1514,6 +1514,12 @@ return [
     'installment-plan.delete' => [
         'description' => 'Delete and restore installment plans',
     ],
+    'deny:installment-plan.read' => [
+        'description' => 'Prohibits reading of the installment plan',
+    ],
+    'deny:installment-plan.delete' => [
+        'description' => 'Prohibits deleting and restoring of the installment plan',
+    ],
     'see-no-mans' => [
         'description' => 'See unsold objects',
         'internal' => true,

--- a/src/files/source/metadata.php
+++ b/src/files/source/metadata.php
@@ -1502,6 +1502,12 @@ return [
     'sale.read' => [
         'description' => 'Read sales',
     ],
+    'installment-plan.read' => [
+        'description' => 'Read installment plans',
+    ],
+    'installment-plan.delete' => [
+        'description' => 'Delete and restore installment plans',
+    ],
     'see-no-mans' => [
         'description' => 'See unsold objects',
         'internal' => true,

--- a/src/files/source/metadata.php
+++ b/src/files/source/metadata.php
@@ -1514,6 +1514,12 @@ return [
     'installment-plan.delete' => [
         'description' => 'Delete and restore installment plans',
     ],
+    'deny:installment-plan.read' => [
+        'description' => 'Prohibits reading of the installment plan',
+    ],
+    'deny:installment-plan.delete' => [
+        'description' => 'Prohibits deleting of the installment plan',
+    ],
     'see-no-mans' => [
         'description' => 'See unsold objects',
         'internal' => true,

--- a/src/files/source/tree.php
+++ b/src/files/source/tree.php
@@ -283,6 +283,12 @@ return [
         'target.delete',
     ],
     // STOCK MODULE
+    'role:installment-plan.user' => [
+        'installment-plan.read', 'sale.read',
+    ],
+    'role:installment-plan.manager' => [
+        'role:installment-plan.user', 'installment-plan.delete',
+    ],
     'role:part.user' => [
         'part.read',
     ],
@@ -377,6 +383,7 @@ return [
         'role:hosting.user',
         'role:finance.user',
         'role:sale.user',
+        'role:installment-plan.user',
         'client.notify',
         'access-subclients',
     ],
@@ -540,6 +547,7 @@ return [
         'see-no-mans',
         'role:blacklist.manager',
         'role:audit.user',
+        'role:installment-plan.manager',
     ],
     'role:almighty' => [
         'role:staff-admin',

--- a/tests/unit/AuthManagerTest.php
+++ b/tests/unit/AuthManagerTest.php
@@ -88,6 +88,7 @@ class AuthManagerTest extends \PHPUnit\Framework\TestCase
             'zone.update',
             'owner-staff',
             'see-no-mans',
+            'installment-plan.delete',
 
             // Roles
             'role:employee.manager',
@@ -133,6 +134,7 @@ class AuthManagerTest extends \PHPUnit\Framework\TestCase
             'role:superpowers',
             'role:owner-staff',
             'role:almighty',
+            'role:installment-plan.manager',
         ];
 
         $actualInternalItems = [];

--- a/tests/unit/CheckAccessTrait.php
+++ b/tests/unit/CheckAccessTrait.php
@@ -117,7 +117,7 @@ trait CheckAccessTrait
             'contact.read', 'contact.create', 'contact.update', 'contact.delete',
             'server.read', 'server.pay', 'server.control-power', 'server.control-system', 'server.set-note',
             'account.read', 'account.create', 'account.update', 'account.delete',
-            'bill.read', 'plan.read', 'finance.read', 'price.read', 'sale.read',
+            'bill.read', 'plan.read', 'finance.read', 'price.read', 'sale.read', 'installment-plan.read',
             'backup.read', 'backup.delete',
             'backuping.read', 'backuping.create', 'backuping.update', 'backuping.delete',
             'crontab.read', 'crontab.create', 'crontab.update', 'crontab.delete',
@@ -563,7 +563,7 @@ trait CheckAccessTrait
             'document.read', 'document.create', 'document.invoice',
             'contact.read', 'contact.create', 'contact.update', 'contact.delete',
             'account.read', 'account.create', 'account.update', 'account.delete',
-            'restore-password', 'bill.read', 'plan.read', 'finance.read', 'price.read', 'sale.read',
+            'restore-password', 'bill.read', 'plan.read', 'finance.read', 'price.read', 'sale.read', 'installment-plan.read',
             'backup.read', 'backup.delete',
             'backuping.read', 'backuping.create', 'backuping.update', 'backuping.delete',
             'crontab.read', 'crontab.create', 'crontab.update', 'crontab.delete',
@@ -629,6 +629,9 @@ trait CheckAccessTrait
             'blacklist.update',
             'blacklist.delete',
             'audit.read',
+            'sale.read',
+            'installment-plan.read',
+            'installment-plan.delete',
         ]);
     }
 }

--- a/tests/unit/CheckAccessTrait.php
+++ b/tests/unit/CheckAccessTrait.php
@@ -461,6 +461,20 @@ trait CheckAccessTrait
         ]);
     }
 
+    public function testInstallmentPlanUser(): void
+    {
+        $this->assertAccesses('role:installment-plan.user', [
+            'installment-plan.read', 'sale.read',
+        ]);
+    }
+
+    public function testInstallmentPlanManager(): void
+    {
+        $this->assertAccesses('role:installment-plan.manager', [
+            'installment-plan.read', 'sale.read', 'installment-plan.delete',
+        ]);
+    }
+
     public function testConsumptionMaster(): void
     {
         $this->assertAccesses('role:consumption.master', [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read and delete permissions for installment plans.
  * Introduced two installment-plan roles: a user role (read) and a manager role (user privileges plus delete).
  * Integrated installment-plan roles into existing client and owner-staff role groups.

* **Tests**
  * Added and updated unit tests to verify the new installment-plan roles and permission expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->