### PR TITLE
HQD-283: add 'pnl.read-source' permission and update roles to include it

### DIFF
--- a/src/files/items.php
+++ b/src/files/items.php
@@ -41,7 +41,6 @@ return [
             'client.get-note',
             'client.set-note',
             'client.read-financial-info',
-            'client.read-requisite',
             'client.read-referral',
             'client.read-deleted',
             'purse.update',
@@ -454,6 +453,7 @@ return [
             'pnl.read',
             'pnl.update',
             'pnl.read-expenses',
+            'pnl.read-source',
         ],
     ],
     'role:pnl.user' => [
@@ -1374,14 +1374,6 @@ return [
     'deny:client.read-financial-info' => [
         'type' => 2,
         'description' => 'Prohibits viewing client\'s financial info',
-    ],
-    'client.read-requisite' => [
-        'type' => 2,
-        'description' => 'Read requisites set to client',
-    ],
-    'deny:client.read-requisite' => [
-        'type' => 2,
-        'description' => 'Prohibits viewing setted requisite to client',
     ],
     'client.read-referral' => [
         'type' => 2,
@@ -2305,6 +2297,14 @@ return [
     'deny:pnl.read-expenses' => [
         'type' => 2,
         'description' => 'Prohibits read-expenses operation on the pnl',
+    ],
+    'pnl.read-source' => [
+        'type' => 2,
+        'description' => 'Read source data in PNL index',
+        'internal' => true,
+    ],
+    'deny:pnl.read-source' => [
+        'type' => 2,
     ],
     'costprice.read' => [
         'type' => 2,

--- a/src/files/source/metadata.php
+++ b/src/files/source/metadata.php
@@ -1930,6 +1930,10 @@ return [
         'description' => 'Read expenses data in PNL report',
         'internal' => true,
     ],
+    'pnl.read-source' => [
+        'description' => 'Read source data in PNL index',
+        'internal' => true,
+    ],
     'pnl.update' => [
         'description' => 'Update PNL report',
         'internal' => true,

--- a/src/files/source/tree.php
+++ b/src/files/source/tree.php
@@ -174,7 +174,7 @@ return [
         'role:purse.manager',
     ],
     'role:pnl.master' => [
-        'pnl.read', 'pnl.update', 'pnl.read-expenses'
+        'pnl.read', 'pnl.update', 'pnl.read-expenses', 'pnl.read-source'
     ],
     'role:pnl.user' => [
         'pnl.read',

--- a/tests/unit/AuthManagerTest.php
+++ b/tests/unit/AuthManagerTest.php
@@ -63,6 +63,7 @@ class AuthManagerTest extends \PHPUnit\Framework\TestCase
             'move.create',
             'pnl.read',
             'pnl.read-expenses',
+            'pnl.read-source',
             'pnl.update',
             'order.read',
             'order.create',

--- a/tests/unit/CheckAccessTrait.php
+++ b/tests/unit/CheckAccessTrait.php
@@ -540,7 +540,7 @@ trait CheckAccessTrait
             'ip.read', 'ip.create', 'ip.update', 'ip.delete',
             'service.read', 'service.create', 'service.update', 'service.delete',
             'costprice.read', 'costprice.create', 'costprice.update', 'costprice.delete',
-            'pnl.read', 'pnl.read-expenses', 'pnl.update',
+            'pnl.read', 'pnl.read-expenses', 'pnl.update', 'pnl.read-source',
             'blacklist.read', 'blacklist.create', 'blacklist.update', 'blacklist.delete',
 
             'purse.set-credit','server.read-wizzard','server.read-legend','server.read-financial-info', 'server.read-system-info',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added internal access to PNL source data for master PNL roles.

* **Changes**
  * Removed requisite-reading access from client manager roles.
  * Updated permission handling to reflect the revised access controls.

* **Tests**
  * Updated authorization checks to cover the new PNL source permission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->