### PR TITLE
HQD-312: grant requisites.read to purse managers via role:requisites.user

### DIFF
--- a/src/files/items.php
+++ b/src/files/items.php
@@ -437,6 +437,7 @@ return [
             'role:purse.user',
             'purse.update',
             'purse.create',
+            'role:requisites.user',
         ],
     ],
     'role:purse.master' => [

--- a/src/files/source/tree.php
+++ b/src/files/source/tree.php
@@ -168,7 +168,7 @@ return [
         'purse.read',
     ],
     'role:purse.manager' => [
-        'role:purse.user', 'purse.update', 'purse.create',
+        'role:purse.user', 'purse.update', 'purse.create', 'role:requisites.user',
     ],
     'role:purse.master' => [
         'role:purse.manager',

--- a/tests/unit/CheckAccessTrait.php
+++ b/tests/unit/CheckAccessTrait.php
@@ -383,6 +383,7 @@ trait CheckAccessTrait
             'client.read-financial-info', 'client.read-referral', 'client.read-deleted', 'client.read-ip',
             'ticket.read-templates', 'ticket.read-statistics', 'ticket.set-private', 'ticket.set-recipient', 'ticket.set-time',
             'target.read', 'target.create', 'target.update', 'target.delete',
+            'requisites.read',
         ]);
     }
 
@@ -459,6 +460,7 @@ trait CheckAccessTrait
             'part.read-administrative', 'ticket.read-templates', 'ticket.read-statistics', 'ticket.set-private', 'ticket.set-recipient', 'ticket.set-time',
             'see-no-mans',
             'target.read', 'target.create', 'target.update', 'target.delete',
+            'requisites.read',
         ]);
     }
 
@@ -552,6 +554,7 @@ trait CheckAccessTrait
             'target.read', 'target.create', 'target.update', 'target.delete',
 
             'installment-plan.read', 'installment-plan.delete', 'installment-plan.update', 'installment-plan.restore', 'installment-plan.process',
+            'requisites.read',
         ]);
     }
 


### PR DESCRIPTION
## Summary
- Continuation/reconciliation of HQD-295: `role:purse.manager` now includes `role:requisites.user`, so purse-manager staff (and everything inheriting it — `role:purse.master`, `role:bill.manager` → `role:bill.staff-manager` → `role:staff-manager`, `role:finance.master` → `role:reseller`/`role:master`/`role:almighty`, and `role:bill.master` → `role:purse.master` → `role:owner`) gain `requisites.read`.
- This matches HQD-295's `'can' => 'requisites.read'` gating added on `purseModule`'s `requisite`/`requisite_id` fields, closing the gap that previously required an ad-hoc `role:requisites.manager` grant for the test manager account.
- Updated `tests/unit/CheckAccessTrait.php` (`testReseller`, `testMighty`, `testAlmighty`) to expect `requisites.read`.

## Test plan
- [x] `vendor/bin/phpunit -c phpunit.xml.dist` — 46 tests, all green

Jira: HQD-312 (relates to HQD-295)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Purse managers can now access requisites functionality.
  * Updated access permissions for reseller, mighty, and almighty roles to include requisites reading.

* **Tests**
  * Expanded access coverage to verify the updated requisites permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->