### PR TITLE
HQD-351: fix test CI job by restoring correct autoload.php path

### DIFF
--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -10,13 +10,25 @@
 
 error_reporting(E_ALL);
 
-require_once __DIR__ . '/../vendor/autoload.php';
+// The package is tested standalone (vendor/ one level up from tests/) as
+// well as from inside a parent project where it's installed as a dependency
+// (vendor/hiqdev/hipanel-rbac/tests/_bootstrap.php, with the parent's
+// vendor/autoload.php three levels up). Support both layouts.
+if (is_dir(__DIR__ . '/../vendor')) {
+    $autoload = __DIR__ . '/../vendor/autoload.php';
+    $yii2 = __DIR__ . '/../vendor/yiisoft/yii2/Yii.php';
+} else {
+    $autoload = __DIR__ . '/../../../autoload.php';
+    $yii2 = __DIR__ . '/../../../yiisoft/yii2/Yii.php';
+}
+
+require_once $autoload;
 
 if (class_exists(\Yiisoft\Factory\Definitions\Reference::class)) {
     $config = require \Yiisoft\Composer\Config\Builder::path('console');
     \yii\helpers\Yii::setContainer(new \yii\di\Container($config));
 } else {
-    require_once __DIR__ . '/../vendor/yiisoft/yii2/Yii.php';
+    require_once $yii2;
 
     Yii::setAlias('@hipanel/rbac', dirname(__DIR__) . '/src');
     Yii::setAlias('@hipanel/rbac/tests', __DIR__);

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -10,13 +10,13 @@
 
 error_reporting(E_ALL);
 
-require_once __DIR__ . '/../../../autoload.php';
+require_once __DIR__ . '/../vendor/autoload.php';
 
 if (class_exists(\Yiisoft\Factory\Definitions\Reference::class)) {
     $config = require \Yiisoft\Composer\Config\Builder::path('console');
     \yii\helpers\Yii::setContainer(new \yii\di\Container($config));
 } else {
-    require_once __DIR__ . '/../../../yiisoft/yii2/Yii.php';
+    require_once __DIR__ . '/../vendor/yiisoft/yii2/Yii.php';
 
     Yii::setAlias('@hipanel/rbac', dirname(__DIR__) . '/src');
     Yii::setAlias('@hipanel/rbac/tests', __DIR__);


### PR DESCRIPTION
## Summary

The `test` CI job has been failing on every run since `72e520a` (#77), which accidentally changed `tests/_bootstrap.php` to require `autoload.php` via a three-levels-up path (`../../../autoload.php`). That path is only correct when this package is installed as a dependency inside another project (`vendor/hiqdev/hipanel-rbac/tests/`); the package's own CI checks itself out standalone, where `vendor/` is one level up from `tests/`, so the require fails and PHPUnit never runs.

## Root cause

The three-levels-up form matches the layout of a downstream consumer's `vendor/hiqdev/hipanel-rbac/tests/_bootstrap.php`. Most likely the author ran `vendor/bin/phpunit` from inside a consuming project's root rather than from this package's own checkout — from there the three-levels-up path resolves and the suite passes locally, masking that it breaks the package's own standalone CI.

## Fix

Rather than a plain revert (which would just move the failure mode to the next person who tests from a consuming project's root), `tests/_bootstrap.php` now auto-detects which layout it's running in by checking whether `../vendor` exists relative to itself, and picks the correct `autoload.php` / `yii2/Yii.php` path accordingly. Works both standalone and as a vendor dependency, with no convention to remember or forget.

## Test plan

- [ ] `test` CI job passes on this PR
- [ ] `vendor/bin/phpunit` succeeds when run from a checkout that has `hipanel-rbac` installed as `vendor/hiqdev/hipanel-rbac`