### PR TITLE
HQD-327: add ticket.export permission for ticket report export

### DIFF
--- a/src/files/items.php
+++ b/src/files/items.php
@@ -1178,6 +1178,7 @@ return [
             'ticket.delete',
             'ticket.read-templates',
             'ticket.read-statistics',
+            'ticket.export',
             'ticket.set-private',
             'ticket.set-recipient',
             'ticket.set-time',
@@ -3294,6 +3295,15 @@ return [
     'deny:ticket.read-statistics' => [
         'type' => 2,
         'description' => 'Prohibits viewing tickets statistics',
+    ],
+    'ticket.export' => [
+        'type' => 2,
+        'description' => 'Export tickets with full message threads for reporting',
+        'internal' => true,
+    ],
+    'deny:ticket.export' => [
+        'type' => 2,
+        'description' => 'Prohibits exporting tickets',
     ],
     'ticket.set-private' => [
         'type' => 2,

--- a/src/files/source/metadata.php
+++ b/src/files/source/metadata.php
@@ -1140,6 +1140,9 @@ return [
     'deny:ticket.read-statistics' => [
         'description' => 'Prohibits viewing tickets statistics',
     ],
+    'deny:ticket.export' => [
+        'description' => 'Prohibits exporting tickets',
+    ],
     'deny:ticket.set-private' => [
         'description' => 'Prohibits setting `private` to answer',
     ],
@@ -1679,6 +1682,10 @@ return [
     ],
     'ticket.read-statistics' => [
         'description' => 'Read ticket statistics',
+    ],
+    'ticket.export' => [
+        'description' => 'Export tickets with full message threads for reporting',
+        'internal' => true,
     ],
     'ticket.set-private' => [
         'description' => 'Make private ticket answers',

--- a/src/files/source/tree.php
+++ b/src/files/source/tree.php
@@ -529,7 +529,7 @@ return [
     ],
     'role:ticket.manager' => [
         'role:ticket.user', 'ticket.update', 'ticket.delete',
-        'ticket.read-templates', 'ticket.read-statistics',
+        'ticket.read-templates', 'ticket.read-statistics', 'ticket.export',
         'ticket.set-private', 'ticket.set-recipient', 'ticket.set-time',
     ],
     'role:beta-tester' => [

--- a/tests/unit/AuthManagerTest.php
+++ b/tests/unit/AuthManagerTest.php
@@ -96,6 +96,7 @@ class AuthManagerTest extends \PHPUnit\Framework\TestCase
             'installment-plan.process',
             'document.see-history',
             'document.replace',
+            'ticket.export',
 
             // Roles
             'role:document.master',
@@ -146,6 +147,7 @@ class AuthManagerTest extends \PHPUnit\Framework\TestCase
             'role:owner-staff',
             'role:almighty',
             'role:installment-plan.manager',
+            'role:ticket.manager',
         ];
 
         $actualInternalItems = [];

--- a/tests/unit/CheckAccessTrait.php
+++ b/tests/unit/CheckAccessTrait.php
@@ -155,7 +155,7 @@ trait CheckAccessTrait
             'ip.read', 'service.read',
             'blacklist.read', 'blacklist.create', 'blacklist.update', 'blacklist.delete',
             'client.read-ip',
-            'ticket.read-templates', 'ticket.read-statistics', 'ticket.set-private', 'ticket.set-recipient', 'ticket.set-time',
+            'ticket.read-templates', 'ticket.read-statistics', 'ticket.export', 'ticket.set-private', 'ticket.set-recipient', 'ticket.set-time',
         ]);
     }
 
@@ -196,7 +196,7 @@ trait CheckAccessTrait
             'blacklist.read', 'blacklist.create', 'blacklist.update', 'blacklist.delete',
 
             'client.read-ip',
-            'ticket.read-templates', 'ticket.read-statistics', 'ticket.set-private', 'ticket.set-recipient', 'ticket.set-time',
+            'ticket.read-templates', 'ticket.read-statistics', 'ticket.export', 'ticket.set-private', 'ticket.set-recipient', 'ticket.set-time',
         ]);
     }
 
@@ -238,7 +238,7 @@ trait CheckAccessTrait
             'service.read', 'service.create', 'service.update', 'service.delete',
             'blacklist.read', 'blacklist.create', 'blacklist.update', 'blacklist.delete',
             'client.read-ip',
-            'ticket.read-templates', 'ticket.read-statistics', 'ticket.set-private', 'ticket.set-recipient', 'ticket.set-time',
+            'ticket.read-templates', 'ticket.read-statistics', 'ticket.export', 'ticket.set-private', 'ticket.set-recipient', 'ticket.set-time',
             'part.read-administrative',
             'see-no-mans',
         ]);
@@ -290,7 +290,7 @@ trait CheckAccessTrait
             'purse.set-credit','server.read-wizzard','server.read-legend', 'server.read-financial-info',
             'server.read-billing','plan.set-note',
             'client.read-financial-info', 'client.read-referral', 'client.read-deleted', 'client.read-ip',
-            'ticket.read-templates', 'ticket.read-statistics', 'ticket.set-private', 'ticket.set-recipient', 'ticket.set-time',
+            'ticket.read-templates', 'ticket.read-statistics', 'ticket.export', 'ticket.set-private', 'ticket.set-recipient', 'ticket.set-time',
             'target.read', 'target.create', 'target.update', 'target.delete',
         ]);
     }
@@ -335,7 +335,7 @@ trait CheckAccessTrait
             'purse.set-credit','server.read-wizzard','server.read-legend','server.read-financial-info',
             'server.read-billing','plan.set-note',
             'client.read-financial-info', 'client.read-referral', 'client.read-deleted', 'client.read-ip',
-            'ticket.read-templates', 'ticket.read-statistics', 'ticket.set-private', 'ticket.set-recipient', 'ticket.set-time',
+            'ticket.read-templates', 'ticket.read-statistics', 'ticket.export', 'ticket.set-private', 'ticket.set-recipient', 'ticket.set-time',
             'target.read', 'target.create', 'target.update', 'target.delete',
 
         ]);
@@ -381,7 +381,7 @@ trait CheckAccessTrait
             'purse.set-credit','server.read-wizzard','server.read-legend','server.read-financial-info',
             'server.read-billing', 'plan.set-note',
             'client.read-financial-info', 'client.read-referral', 'client.read-deleted', 'client.read-ip',
-            'ticket.read-templates', 'ticket.read-statistics', 'ticket.set-private', 'ticket.set-recipient', 'ticket.set-time',
+            'ticket.read-templates', 'ticket.read-statistics', 'ticket.export', 'ticket.set-private', 'ticket.set-recipient', 'ticket.set-time',
             'target.read', 'target.create', 'target.update', 'target.delete',
             'requisites.read',
         ]);
@@ -457,7 +457,7 @@ trait CheckAccessTrait
             'purse.set-credit','server.read-wizzard','server.read-legend','server.read-system-info', 'server.read-financial-info',
             'server.read-billing','server.assign-hub','plan.set-note',
             'client.read-financial-info', 'client.read-referral', 'client.read-deleted', 'client.read-ip',
-            'part.read-administrative', 'ticket.read-templates', 'ticket.read-statistics', 'ticket.set-private', 'ticket.set-recipient', 'ticket.set-time',
+            'part.read-administrative', 'ticket.read-templates', 'ticket.read-statistics', 'ticket.export', 'ticket.set-private', 'ticket.set-recipient', 'ticket.set-time',
             'see-no-mans',
             'target.read', 'target.create', 'target.update', 'target.delete',
             'requisites.read',
@@ -548,7 +548,7 @@ trait CheckAccessTrait
             'purse.set-credit','server.read-wizzard','server.read-legend','server.read-financial-info', 'server.read-system-info',
             'server.read-billing','server.assign-hub', 'plan.set-note',
             'client.read-financial-info', 'client.read-referral', 'client.read-deleted', 'client.read-ip',
-            'part.read-administrative', 'ticket.read-templates', 'ticket.read-statistics', 'ticket.set-private', 'ticket.set-recipient', 'ticket.set-time',
+            'part.read-administrative', 'ticket.read-templates', 'ticket.read-statistics', 'ticket.export', 'ticket.set-private', 'ticket.set-recipient', 'ticket.set-time',
 
             'see-no-mans', 'bill.charges.read', 'bill.charges.change_invoiced', 'bill.see-server-charges',
             'target.read', 'target.create', 'target.update', 'target.delete',


### PR DESCRIPTION
Grants role:ticket.manager the ability to export tickets with full message threads (needed for the new ticketsExport API command in hiapi-legacy). Marked internal, following the audit.read convention, since it's a staff-only reporting capability that exposes internal notes and PII across all clients.

Updates source files (tree.php, metadata.php) and the generated items.php in lockstep, plus the exhaustive per-role assertions in CheckAccessTrait and the internal-items list in
AuthManagerTest::testIsRoleInternal, per this repo's documented "Adding a new permission" checklist.